### PR TITLE
FEAT : APPException 정의 및 처리

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,12 @@
 from fastapi import FastAPI
+from utils.appExceptions import AppExceptionCase, app_exception_handler
 
 store = dict()
 app = FastAPI()
 
-
+@app.exception_handler(AppExceptionCase)
+async def custom_app_exception_handler(request, e):
+    return await app_exception_handler(request, e)
 @app.get("/")
 async def root():
     return {"message": "Hello World"}

--- a/app/utils/appExceptions.py
+++ b/app/utils/appExceptions.py
@@ -1,4 +1,8 @@
-class APPExceptionCase(Exception):
+from fastapi import Request
+from starlette.responses import JSONResponse
+
+
+class AppExceptionCase(Exception):
     def __init__(self, status_code: int, context: dict):
         self.exception_case = self.__class__.__name__
         self.status_code = status_code
@@ -6,6 +10,36 @@ class APPExceptionCase(Exception):
 
     def __str__(self):
         return (
-            f"<AppException {self.exception_case} - "
-            + f"status_code={self.status_code} - context{self.context}>"
+                f"<AppException {self.exception_case} - "
+                + f"status_code={self.status_code} - context{self.context}>"
         )
+
+
+async def app_exception_handler(request: Request, exc: AppExceptionCase):
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={
+            "app_exception": exc.exception_case,
+            "context": exc.context,
+        },
+    )
+
+
+class AppException(object):
+    class GetItem(AppExceptionCase):
+        def __init__(self, context: dict = None):
+            """
+            Item not found
+            :param context:
+            """
+            status_code = 404
+            AppExceptionCase.__init__(self, status_code, context)
+
+    class ValidateValueLength(AppExceptionCase):
+        def __init__(self, context: dict = None):
+            """
+            Value is more than 1024 bytes
+            :param context:
+            """
+            status_code = 413
+            AppExceptionCase.__init__(self, status_code, context)


### PR DESCRIPTION
- GetItem: key가 store에 존재하지 않는 경우 발생하는 예외
- ValidateValueLength: value가 1024 bytes를 넘어갈 때 발생하는 예외
- app_exception_handler로 처리 (app/main.py에 등록)